### PR TITLE
ffmpeg command fixes for download errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -199,11 +199,13 @@ const getTokenizedUrl = async (url, content, channel) => {
         let audioStreamMapping = (audioStreamId !== -1) ? ['-map', `0:p:${programStream}:a:${audioStreamId}`] : ['-map', `0:p:${programStream}:a`];
         //let audioCodecParameters = (false) ? ['-c:a', 'aac', '-ar', '48000', '-b:a', '256k'] : ['-c:a', 'copy']; // leaving this in case they switch races back to 96kHz audio
         let audioCodecParameters = ['-c:a', 'copy'];
-        let inputOptions = [
+        const inputOptions = [
             '-probesize', '24M',
+            '-analyzeduration', '6M',
             '-rtbufsize', '2147M'
-            //'-live_start_index', '0'
         ];
+
+        let pitInputOptions = [...inputOptions];
 
         if (audioStreamId !== -1) {
             log.info(`Found audio stream that matches ${config.makeItGreen(audioStream)}.`);
@@ -226,8 +228,9 @@ const getTokenizedUrl = async (url, content, channel) => {
 
             log.debug('pit url:', pitUrl);
 
-            inputOptions.push(...[
-                '-itsoffset', itsoffset
+            pitInputOptions.push(...[
+                '-itsoffset', itsoffset,
+                //'-live_start_index', '50'
             ]);
 
             audioStreamMapping = [
@@ -278,9 +281,9 @@ const getTokenizedUrl = async (url, content, channel) => {
             ?  // Use this command when adding pitlane audio
             ffmpeg()
                 .input(f1tvUrl)
-                //.inputOptions(['-live_start_index', '0'])
-                .input(pitUrl)
                 .inputOptions(inputOptions)
+                .input(pitUrl)
+                .inputOptions(pitInputOptions)
                 .outputOptions(options)
                 .on('start', commandLine => {
                     log.debug('Executing command:', config.makeItGreen(commandLine));
@@ -306,7 +309,7 @@ const getTokenizedUrl = async (url, content, channel) => {
             : // Use this command for everything else
             ffmpeg()
                 .input(f1tvUrl)
-                //.inputOptions(['-live_start_index', '0'])
+                .inputOptions(inputOptions)
                 .outputOptions(options)
                 .on('start', commandLine => {
                     log.debug('Executing command:', config.makeItGreen(commandLine));

--- a/package-lock.json
+++ b/package-lock.json
@@ -861,9 +861,9 @@
       }
     },
     "@thedave42/fluent-ffmpeg": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@thedave42/fluent-ffmpeg/-/fluent-ffmpeg-1.0.4.tgz",
-      "integrity": "sha512-Dn62ncPvS+IekfNwm55BdTZ/qiQj3U2KIQ76aVUmRMWm1tDmlszi+xC5EL6kamT+7SySJ1S4aFaKVXzeutJ0DA==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@thedave42/fluent-ffmpeg/-/fluent-ffmpeg-1.0.5.tgz",
+      "integrity": "sha512-AG9qxPqHk2nGp4pH7imSeK7qELYcjqEf3Gcoit1P8IanOBGZmFTN8/HHOwNZNiXspaUCsdrv7kyeBhTz5Xwi0w==",
       "requires": {
         "async": ">=0.2.9",
         "which": "^1.1.1"
@@ -1316,9 +1316,9 @@
       "dev": true
     },
     "async": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.1.tgz",
-      "integrity": "sha512-XdD5lRO/87udXCMC9meWdYiR+Nq6ZjUfXidViUZGu2F1MO4T3XwZ1et0hb2++BgLfhyJwy44BGB/yx80ABx8hg=="
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.2.tgz",
+      "integrity": "sha512-H0E+qZaDEfx/FY4t7iLRv1W2fFI6+pyCeTw1uN20AQPiwqwM6ojPxHxdLv4z8hi2DtnW9BOckSspLucW7pIE5g=="
     },
     "asynckit": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "author": "dave@digitalnoise.net",
   "license": "ISC",
   "dependencies": {
-    "@thedave42/fluent-ffmpeg": "^1.0.4",
+    "@thedave42/fluent-ffmpeg": "^1.0.5",
     "axios": "^0.24.0",
     "dotenv": "^10.0.0",
     "hls-parser": "^0.10.4",


### PR DESCRIPTION
Needed to add a longer `-analyzeduration` for ffmpeg command in order to ensure the right info is extracted from hls segments.